### PR TITLE
Extend travis yml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ smalltalk:
 #cache:
 #  directories:
 #    - $SMALLTALK_CI_CACHE
+
+# Uncomment to override automatic smalltalkCI execution
+#script:
+#  - "$SMALLTALK_CI_HOME/run.sh"
+#  - "$SMALLTALK_CI_HOME/run.sh" .mysmalltalk.ston
+#  - travis_wait "$SMALLTALK_CI_HOME/run.sh"
+
 ```
 
 ### `appveyor.yml` Template


### PR DESCRIPTION
Extend the travis yml template to make explicit how to override the default `script:` entry